### PR TITLE
patch: fixed CI.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - development
+  pull_request:
+    branches:
+      - feature/*
 
 jobs:
   test:
@@ -19,11 +22,14 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install Yarn
+        run: npm install -g yarn
+
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Run tests
-        run: npm run test
+        run: yarn test
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
changes made:

1.  Added `pull_request` to the `on` section with a pattern for feature branches:
    
    
    ```yaml
    pull_request:
      branches:
        - feature/*
    ```
    
2.  Added a step to install Yarn globally:
    
     ```yaml
     - name: Install Yarn
      run: npm install -g yarn
    ```
    
3.  Replaced `npm ci` with `yarn install --frozen-lockfile`:
    
```yaml 
   - name: Install dependencies
      run: yarn install --frozen-lockfile 
    ```
4.  Replaced `npm run test` with `yarn test`:
    
    
    ```yaml    
- name: Run tests
      run: yarn test` 
        ```

With these changes, the pipeline will use Yarn to install dependencies and run tests. Additionally, it will be triggered when a pull request is created for feature branches with a `feature/*` pattern.